### PR TITLE
Introduce lazy loading for icons in slot lists

### DIFF
--- a/pkg/website/templates/index.html
+++ b/pkg/website/templates/index.html
@@ -51,7 +51,7 @@
                 {{ range $l := .Results }}
                 <tr>
                     <td><a class="table-link" href="/slot/{{ $l.ID }}">
-                        <img style="width:128px;" src="/icon/{{ $l.Icon }}" alt="the level icon" aria-hidden="true" onerror="this.style.display='none'"/>
+                        <img style="width:128px;" src="/icon/{{ $l.Icon }}" alt="the level icon" aria-hidden="true" onerror="this.style.display='none'" loading="lazy"/>
                     </a></td>
                     <td><a class="table-link" href="/slot/{{ $l.ID }}">{{ $l.ID }}</a></td>
                     <td><a class="table-link" href="/slot/{{ $l.ID }}">{{ $l.Name }}</a></td>

--- a/pkg/website/templates/user.html
+++ b/pkg/website/templates/user.html
@@ -42,7 +42,7 @@
     </tr>
     {{ range $l := .Results }}
     <tr>
-        <td><a class="table-link" href="/slot/{{ $l.ID }}"><img style="width:128px;" src="/icon/{{ $l.Icon }}" alt="the level icon" aria-hidden="true" onerror="this.style.display='none'"/></a></td>
+        <td><a class="table-link" href="/slot/{{ $l.ID }}"><img style="width:128px;" src="/icon/{{ $l.Icon }}" alt="the level icon" aria-hidden="true" onerror="this.style.display='none'" loading="lazy"/></a></td>
         <td><a class="table-link" href="/slot/{{ $l.ID }}">{{ $l.ID }}</a></td>
         <td><a class="table-link" href="/slot/{{ $l.ID }}">{{ $l.Name }}</a></td>
         <td><a class="table-link" href="/slot/{{ $l.ID }}">{{ $l.Description }}</a></td>


### PR DESCRIPTION
The way the Dry Archive works on production Refresh's backend is a little weird and ends up being a performance bottleneck; it's mounted on an NFS and we've observed lots of latency when asking for many resources at once: ![image](https://github.com/user-attachments/assets/613b5ab7-684e-42b9-a7f0-32de610765c5)

I've noticed that in a few cases, the process of fully loading a page's icons can even take upwards to a few seconds, which ends up not being that far ahead of loading from archive.org as a source.

By lazy-loading on the client side, you can reduce the volume of the initial burst of requests as a user loads uncached level icons and more effectively use our bandwidth internally, rapidly reducing latency for those icons. Further requests will be spread out as the user scrolls through the page.

Observe our new request times with this patch:

![image](https://github.com/user-attachments/assets/91705c3f-a290-45dc-a345-e58a18d31e3e)

Still quite high, but much better (highest is 844ms/571ms instead of the previous 1466ms/1310ms)